### PR TITLE
Attached sources and javadocs to the resulting jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,33 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
-
             </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-source-plugin</artifactId>
+            	<version>3.0.1</version>
+            	<executions>
+            		<execution>
+            			<id>attach-sources</id>
+            			<goals>
+            				<goal>jar</goal>
+            			</goals>
+            		</execution>
+            	</executions>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-javadoc-plugin</artifactId>
+            	<version>3.0.1</version>
+            	<executions>
+            		<execution>
+            			<id>attach-javadocs</id>
+            			<goals>
+            				<goal>jar</goal>
+            			</goals>
+            		</execution>
+            	</executions>
+            </plugin>            
         </plugins>
     </build>
 


### PR DESCRIPTION
- Attached java sources and javadocs
- Usually integrates nicely with IDEs

If really both sources and javadocs are required (especially since javadoc creation takes some time) is debatable. Nevertheless, the inclusion of at least the sources makes it easy for eclipse to find them, if requested.