### PR TITLE
Resolve a bug with cell spanning and word wrap.

### DIFF
--- a/src/main/java/org/vandeseer/easytable/structure/Table.java
+++ b/src/main/java/org/vandeseer/easytable/structure/Table.java
@@ -121,15 +121,16 @@ public class Table {
                 row.setTable(table);
                 row.getSettings().fillingMergeBy(table.getSettings());
 
-                for (int i = 0; i < row.getCells().size(); i++) {
-                    CellBaseData cell = row.getCells().get(i);
+                int columnNumber = 0;
+                for(CellBaseData cell : row.getCells()) {
 
                     cell.setRow(row);
-                    cell.setColumn(table.getColumns().get(i));
+                    cell.setColumn(table.getColumns().get(columnNumber));
 
                     if (cell instanceof CellText) {
                         ((CellText) cell).getSettings().fillingMergeBy(row.getSettings());
                     }
+                    columnNumber += cell.getSpan();
                 }
             }
 

--- a/src/test/java/org/vandeseer/easytable/structure/TableTest.java
+++ b/src/test/java/org/vandeseer/easytable/structure/TableTest.java
@@ -65,5 +65,25 @@ public class TableTest {
         // highest cell (60) + font height
         assertThat(table.getHeight(), equalTo(58.616f));
     }
+    
+    @Test
+    public void testCellSpanning() {
+        final TableBuilder tableBuilder = new TableBuilder();
+        tableBuilder.addColumnOfWidth(12)
+                .addColumnOfWidth(34)
+                .addColumnOfWidth(12);
+        final Row row = new RowBuilder()
+                .add(CellText.builder().text("11").span(2).build())
+                .add(CellText.builder().text("12").paddingTop(15).paddingBottom(25).build())
+                .build();
+        tableBuilder.addRow(row);
+        final Table table = tableBuilder
+                .build();
+
+        CellText cell = (CellText) table.getRows().get(0).getCells().get(1);
+        Column lastColumn = table.getColumns().get(table.getColumns().size()-1);
+        // column does not implement equals/hashCode - but the object is really identical "==" comparison possible
+        assertThat("Second table cell should be linked with the third (last) column!", lastColumn==cell.getColumn()); 
+    }
 
 }


### PR DESCRIPTION
- Word wrap with cell spanning confuses table columns
 - Example: table width - 10,10,30,20,10
 - Cell 1 spans 2 columns (10+10)
 - Cell 2 should have width 30, but width 10 is returned
 - Cell 3 should have width 20, but width 30 is returned
 ...