### PR TITLE
#23 Methods and fallbacks for word breaking to be used in heights and widths

### DIFF
--- a/src/main/java/org/vandeseer/easytable/structure/Row.java
+++ b/src/main/java/org/vandeseer/easytable/structure/Row.java
@@ -27,6 +27,13 @@ public class Row {
     @Getter
     private List<CellBaseData> cells;
 
+    private Color textColor;
+    private Color borderColor;
+    private Color backgroundColor;
+
+    @Setter
+    private boolean wordBreak;
+
     @Getter
     @Setter(AccessLevel.NONE)
     private Settings settings;
@@ -45,6 +52,10 @@ public class Row {
                 .orElseThrow(RuntimeException::new);
 
         return Math.max(height, maxCellHeight);
+    }
+
+    public boolean isWordBreak() {
+        return getTable() == null ? wordBreak : getTable().isWordBreak();
     }
 
 
@@ -101,6 +112,12 @@ public class Row {
             final Row row = new Row(cells);
             row.settings = settings;
             row.height = height;
+
+            for (CellBaseData cell : row.getCells()) {
+                cell.getSettings().fillingMergeBy(row.getSettings());
+                cell.setRow(row);
+            }
+
             return row;
         }
 

--- a/src/main/java/org/vandeseer/easytable/structure/Table.java
+++ b/src/main/java/org/vandeseer/easytable/structure/Table.java
@@ -81,6 +81,15 @@ public class Table {
                         "Number of row cells does not match with number of table columns");
             }
             rows.add(row);
+            row.setWordBreak(wordBreak);
+            return this;
+        }
+
+        public TableBuilder wordBreak(boolean wordBreak) {
+            this.wordBreak = wordBreak;
+            for (Row row : rows) {
+                row.setWordBreak(wordBreak);
+            }
             return this;
         }
 

--- a/src/main/java/org/vandeseer/easytable/structure/cell/CellBaseData.java
+++ b/src/main/java/org/vandeseer/easytable/structure/cell/CellBaseData.java
@@ -54,6 +54,9 @@ public abstract class CellBaseData {
     @Builder.Default
     private float borderWidthBottom = 0;
 
+    @Builder.Default
+    private boolean wordBreak = false;
+
     public float getHorizontalPadding() {
         return getPaddingLeft() + getPaddingRight();
     }
@@ -88,6 +91,10 @@ public abstract class CellBaseData {
 
     public Color getBorderColor() {
         return settings.getBorderColor();
+    }
+
+    public boolean isWordBreak(){
+        return getRow() == null ? wordBreak : getRow().isWordBreak();
     }
 
     public abstract float getHeight();

--- a/src/main/java/org/vandeseer/easytable/structure/cell/CellText.java
+++ b/src/main/java/org/vandeseer/easytable/structure/cell/CellText.java
@@ -46,7 +46,7 @@ public class CellText extends CellBaseData {
         final float textHeight;
         final float fontHeight = PdfUtil.getFontHeight(getFont(), getFontSize());
 
-        if (getRow().getTable().isWordBreak()) {
+        if (isWordBreak()) {
 
             final int size = PdfUtil.getOptimalTextBreakLines(text, getFont(), getFontSize(),
                     getWidthOfTextAndHorizontalPadding() - getHorizontalPadding()).size();
@@ -68,7 +68,7 @@ public class CellText extends CellBaseData {
 
         final float textWidth;
 
-        if (getRow().getTable().isWordBreak()) {
+        if (isWordBreak()) {
 
             float columnsWidth = getColumn().getWidth();
 

--- a/src/test/java/org/vandeseer/easytable/structure/cell/CellTextTest.java
+++ b/src/test/java/org/vandeseer/easytable/structure/cell/CellTextTest.java
@@ -159,6 +159,7 @@ public class CellTextTest {
 
     private void enableWordBreaking() {
         when(table.isWordBreak()).thenReturn(true);
+        when(row.isWordBreak()).thenReturn(true);
     }
 
     private void setColumnWidthTo(float width) {

--- a/src/test/java/org/vandeseer/integrationtest/RowHeightTest.java
+++ b/src/test/java/org/vandeseer/integrationtest/RowHeightTest.java
@@ -1,0 +1,41 @@
+package org.vandeseer.integrationtest;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.vandeseer.easytable.structure.Row;
+import org.vandeseer.easytable.structure.Table;
+import org.vandeseer.easytable.structure.cell.CellText;
+
+import static org.apache.pdfbox.pdmodel.font.PDType1Font.COURIER_BOLD;
+import static org.apache.pdfbox.pdmodel.font.PDType1Font.HELVETICA;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.vandeseer.easytable.settings.HorizontalAlignment.CENTER;
+
+public class RowHeightTest {
+
+    @Test
+    public void testHeightBeforeAndAfterBuild() {
+        final Table.TableBuilder tableBuilder = Table.builder()
+                .addColumnsOfWidth(100, 100, 100)
+                .horizontalAlignment(CENTER)
+                .fontSize(10).font(HELVETICA);
+
+        Row row = Row.builder()
+                .add(CellText.builder().text(RandomStringUtils.randomAlphabetic(23)).span(2).borderWidth(1).build())
+                .add(CellText.builder().text("Booz").build())
+                .font(COURIER_BOLD).fontSize(8)
+                .build();
+
+        tableBuilder.addRow(row);
+
+        float heightBefore = row.getHeight();
+
+        tableBuilder.build();
+
+        float heightAfter = row.getHeight();
+
+        assertThat(heightAfter, equalTo(heightBefore));
+    }
+
+}


### PR DESCRIPTION
I've written a test that covers the unwanted behavior and have changed the word breaking logic so that Rows and Cells have fallbacks in case the Table is not built yet.

This could be expanded to allow for cell and row wise word breaking overrides but for now this only restores the old behavior where calling `wordBreak` on `TableBuilder` would allow for the `TableBuilder`s rows to determine their heights and widths without building the table.