### PR TITLE
Remove apache commons lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.4</version>

--- a/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
+++ b/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
@@ -1,7 +1,6 @@
 package org.vandeseer.easytable.util;
 
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 
 import java.io.IOException;
@@ -118,13 +117,13 @@ public class PdfUtil {
         final List<String> splitBySpace = Arrays.asList(line.split(" "));
 
         for (int i = splitBySpace.size() - 1; i >= 0; i--) {
-            final String fittedNewLine = StringUtils.join(splitBySpace.subList(0, i), " ");
-            final String remains = StringUtils.join(splitBySpace.subList(i, splitBySpace.size()), " ");
+            final String fittedNewLine = String.join(" ", splitBySpace.subList(0, i));
+            final String remains = String.join(" ", splitBySpace.subList(i, splitBySpace.size()));
 
-            if (!StringUtils.isEmpty(fittedNewLine) && PdfUtil.doesTextLineFit(fittedNewLine, font, fontSize, maxWidth)) {
+            if (!fittedNewLine.isEmpty() && PdfUtil.doesTextLineFit(fittedNewLine, font, fontSize, maxWidth)) {
                 returnList.add(fittedNewLine);
 
-                if (!StringUtils.equals(remains, line)) {
+                if (!Objects.equals(remains, line)) {
                     returnList.addAll(PdfUtil.wrapLine(remains, font, fontSize, maxWidth));
                 }
                 break;

--- a/src/test/java/org/vandeseer/easytable/structure/RowTest.java
+++ b/src/test/java/org/vandeseer/easytable/structure/RowTest.java
@@ -1,6 +1,5 @@
 package org.vandeseer.easytable.structure;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -39,7 +38,7 @@ public class RowTest {
                 .wordBreak(false);
 
         final Row row = Row.builder()
-                .add(CellText.builder().text(RandomStringUtils.randomAlphabetic(23)).colSpan(2).borderWidth(1).build())
+                .add(CellText.builder().text("iVgebALheQlBkxtDyNDrhKv").colSpan(2).borderWidth(1).build())
                 .add(CellText.builder().text("Booz").build())
                 .font(COURIER_BOLD).fontSize(8)
                 .build();

--- a/src/test/java/org/vandeseer/integrationtest/SettingsOverridingTest.java
+++ b/src/test/java/org/vandeseer/integrationtest/SettingsOverridingTest.java
@@ -1,6 +1,5 @@
 package org.vandeseer.integrationtest;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.vandeseer.TestUtils;
 import org.vandeseer.easytable.structure.Row;
@@ -33,7 +32,7 @@ public class SettingsOverridingTest {
 
         tableBuilder.addRow(
                 Row.builder()
-                        .add(CellText.builder().text(RandomStringUtils.randomAlphabetic(23)).colSpan(2).borderWidth(1).build())
+                        .add(CellText.builder().text("FCmjGVylqCjoxxfFWhehSrm").colSpan(2).borderWidth(1).build())
                         .add(CellText.builder().text("Booz").build())
                         .font(COURIER_BOLD).fontSize(8)
                         .build());
@@ -73,7 +72,7 @@ public class SettingsOverridingTest {
 
         tableBuilder.addRow(
                 Row.builder()
-                        .add(CellText.builder().text(RandomStringUtils.randomAlphabetic(23)).colSpan(2).borderWidth(1).build())
+                        .add(CellText.builder().text("OWpTlEgQPoSmoyjdNcQdVbc").colSpan(2).borderWidth(1).build())
                         .add(CellText.builder().text("Booz").borderWidth(1).build())
                         .build());
 


### PR DESCRIPTION
Removing apache commons lang3 dependency, as it was hardly used.

Summary of usage:
* In `main`, only `StringUtils` methods were used. `StringUtils.join` is substituted with Java 8 `String.join`. 
* In `test`, only `RandomStringUtils`'s `randomAlphabetic` was used but with the same length of 23. Is simply replaced with a String created from `RandomStringUtils.randomAlphabetic(23)`.