### PR TITLE
Better text-breaking of cells

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.vandeseer</groupId>
     <artifactId>easytable</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2-DEV</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.vandeseer</groupId>
     <artifactId>easytable</artifactId>
-    <version>0.5.3-DEV</version>
+    <version>0.5.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.vandeseer</groupId>
     <artifactId>easytable</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -103,13 +103,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>12</source>
+                    <target>12</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.8</version>
+                            <version>1.18.10</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.vandeseer</groupId>
     <artifactId>easytable</artifactId>
-    <version>0.5.2-DEV</version>
+    <version>0.5.3-DEV</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.vandeseer</groupId>
     <artifactId>easytable</artifactId>
-    <version>0.6.0</version>
+    <version>0.5.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>12</source>
-                    <target>12</target>
+                    <source>11</source>
+                    <target>11</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
+++ b/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
@@ -105,7 +105,6 @@ public class PdfUtil {
         List<String> result = new ArrayList<>();
         result.add(line);
 
-        final List<String> splitValues = List.of(" ", "\\.", ",");
         final Map<String, String> splitByAndReplacementMap = Map.of(" ", " ",
                 "\\.", ".",
                 ",", ",");
@@ -221,10 +220,6 @@ public class PdfUtil {
     private static class CouldNotDetermineStringWidthException extends RuntimeException {
         CouldNotDetermineStringWidthException() {
             super();
-        }
-
-        CouldNotDetermineStringWidthException(Exception exception) {
-            super(exception);
         }
     }
 

--- a/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
+++ b/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
@@ -105,7 +105,7 @@ public class PdfUtil {
         List<String> result = new ArrayList<>();
         result.add(line);
 
-        final List<String> splitValues = List.of(" ", ".", ",");
+        final List<String> splitValues = List.of(" ", "\\.", ",");
 
         for (final String splitWith : splitValues) {
             result = result.stream()

--- a/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
+++ b/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
@@ -106,11 +106,17 @@ public class PdfUtil {
         result.add(line);
 
         final List<String> splitValues = List.of(" ", "\\.", ",");
+        final Map<String, String> splitByAndReplacementMap = Map.of(" ", " ",
+                "\\.", ".",
+                ",", ",");
 
-        for (final String splitWith : splitValues) {
+        for (Map.Entry<String, String> entry : splitByAndReplacementMap.entrySet()) {
+            final String splitRegex = entry.getKey();
+            final String replacement = entry.getValue();
+
             result = result.stream()
                     .flatMap(subLine -> {
-                        List<String> newLines = PdfUtil.splitBy(splitWith, subLine, font, fontSize, maxWidth);
+                        List<String> newLines = PdfUtil.splitBy(splitRegex, subLine, font, fontSize, maxWidth, replacement);
 
                         if (newLines.isEmpty()) {
                             newLines.add(line);
@@ -170,17 +176,18 @@ public class PdfUtil {
                                         final String line,
                                         final PDFont font,
                                         final int fontSize,
-                                        final float maxWidth) {
+                                        final float maxWidth,
+                                        final String replacementString) {
 
         final List<String> returnList = new ArrayList<>();
         final List<String> splitBy = Arrays.asList(line.split(by));
 
         for (int i = splitBy.size() - 1; i >= 0; i--) {
-            final String fittedNewLine = String.join(by, splitBy.subList(0, i));
-            final String remains = String.join(by, splitBy.subList(i, splitBy.size()));
+            final String fittedNewLine = String.join(replacementString, splitBy.subList(0, i));
+            final String remains = String.join(replacementString, splitBy.subList(i, splitBy.size()));
 
             if (!fittedNewLine.isEmpty() && PdfUtil.doesTextLineFit(fittedNewLine, font, fontSize, maxWidth)) {
-                returnList.add(String.format("%s%s", fittedNewLine, by).trim());
+                returnList.add(String.format("%s%s", fittedNewLine, replacementString).trim());
 
                 if (!Objects.equals(remains, line)) {
                     returnList.addAll(PdfUtil.wrapLine(remains, font, fontSize, maxWidth));


### PR DESCRIPTION
Try to break at spaces, dots (`.`) and commas (`,`), before wrapping words.