### PR TITLE
Remove compile scope maven-gpg-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,6 @@
             <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <type>maven-plugin</type>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Running `mvn dependency:tree` on easytable yields:

```
[INFO] -------------------< com.github.vandeseer:easytable >-------------------
[INFO] Building easytable 0.5.3-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ easytable ---
[INFO] com.github.vandeseer:easytable:jar:0.5.3-SNAPSHOT
[INFO] +- org.apache.pdfbox:pdfbox:jar:2.0.17:compile
[INFO] |  +- org.apache.pdfbox:fontbox:jar:2.0.17:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.10:provided
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.hamcrest:hamcrest-library:jar:1.3:test
[INFO] +- org.mockito:mockito-core:jar:2.23.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.9.0:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.9.0:test
[INFO] |  \- org.objenesis:objenesis:jar:2.6:test
[INFO] \- org.apache.maven.plugins:maven-gpg-plugin:maven-plugin:1.6:compile
[INFO]    +- org.apache.maven:maven-plugin-api:jar:2.2.1:compile
[INFO]    +- org.apache.maven:maven-project:jar:2.2.1:compile
[INFO]    |  +- org.apache.maven:maven-settings:jar:2.2.1:compile
[INFO]    |  +- org.apache.maven:maven-profile:jar:2.2.1:compile
[INFO]    |  +- org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
[INFO]    |  |  +- org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-6:compile
[INFO]    |  |  \- backport-util-concurrent:backport-util-concurrent:jar:3.1:compile
[INFO]    |  +- org.apache.maven:maven-plugin-registry:jar:2.2.1:compile
[INFO]    |  +- org.codehaus.plexus:plexus-interpolation:jar:1.11:compile
[INFO]    |  \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
[INFO]    |     \- classworlds:classworlds:jar:1.1-alpha-2:compile
[INFO]    +- org.apache.maven:maven-artifact:jar:2.2.1:compile
[INFO]    +- org.apache.maven:maven-repository-metadata:jar:2.2.1:compile
[INFO]    +- org.apache.maven:maven-model:jar:2.2.1:compile
[INFO]    +- org.codehaus.plexus:plexus-utils:jar:3.0.20:compile
[INFO]    \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4:compile
[INFO]       \- org.sonatype.plexus:plexus-cipher:jar:1.4:compile
```

I was surprised to find `org.apache.maven.plugins:maven-gpg-plugin` listed as a compile scope dependency in the pom. 

I ran `mvn clean install` and the `maven-gpg-plugin:1.6:sign` goal still executed as expected (of course with the key failing). So I'm unsure why it's needed as a dependency when it's defined as a plugin.

If I'm in error, please disregard!

Quick fix: add an `<exclusion>` for the `maven-gpg-plugin`

```
<dependency>
    <groupId>com.github.vandeseer</groupId>
    <artifactId>easytable</artifactId>
    <version>${easytable.version}</version>
    <exclusions>
        <exclusion>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-gpg-plugin</artifactId>
        </exclusion>
    </exclusions>
</dependency>
```

And the dependency tree becomes:
```
[INFO] -------------------< com.github.vandeseer:easytable >-------------------
[INFO] Building easytable 0.5.3-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ easytable ---
[INFO] com.github.vandeseer:easytable:jar:0.5.3-SNAPSHOT
[INFO] +- org.apache.pdfbox:pdfbox:jar:2.0.17:compile
[INFO] |  +- org.apache.pdfbox:fontbox:jar:2.0.17:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.10:provided
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.hamcrest:hamcrest-library:jar:1.3:test
[INFO] \- org.mockito:mockito-core:jar:2.23.0:test
[INFO]    +- net.bytebuddy:byte-buddy:jar:1.9.0:test
[INFO]    +- net.bytebuddy:byte-buddy-agent:jar:1.9.0:test
[INFO]    \- org.objenesis:objenesis:jar:2.6:test
```
