### PR TITLE
Added MIT License to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
A small change to add the MIT license to the `pom.xml`.

This is useful because at the moment, as far as I can tell, there's no record of the license in the maven distribution
https://repo1.maven.org/maven2/com/github/vandeseer/easytable/0.6.4/

So this would clarify that it is the license being used.

Thanks