### PR TITLE
support superscript at the end of the text

### DIFF
--- a/src/main/java/org/vandeseer/easytable/drawing/DrawingUtil.java
+++ b/src/main/java/org/vandeseer/easytable/drawing/DrawingUtil.java
@@ -12,6 +12,7 @@ public class DrawingUtil {
 
     public static void drawText(PDPageContentStream contentStream, PositionedStyledText styledText) throws IOException {
         contentStream.beginText();
+        contentStream.setTextRise(styledText.getTextRise());
         contentStream.setNonStrokingColor(styledText.getColor());
         contentStream.setFont(styledText.getFont(), styledText.getFontSize());
         contentStream.newLineAtOffset(styledText.getX(), styledText.getY());

--- a/src/main/java/org/vandeseer/easytable/drawing/PositionedStyledText.java
+++ b/src/main/java/org/vandeseer/easytable/drawing/PositionedStyledText.java
@@ -16,5 +16,6 @@ public class PositionedStyledText {
     private final PDFont font;
     private final int fontSize;
     private final Color color;
+    private final float textRise;
 
 }

--- a/src/main/java/org/vandeseer/easytable/drawing/cell/TextCellDrawer.java
+++ b/src/main/java/org/vandeseer/easytable/drawing/cell/TextCellDrawer.java
@@ -61,8 +61,12 @@ public class TextCellDrawer<T extends AbstractTextCell> extends AbstractCellDraw
 
             // Handle horizontal alignment by adjusting the xOffset
             if (cell.isHorizontallyAligned(RIGHT)) {
-                xOffset = startX + (cell.getWidth() - (textWidth + cell.getPaddingRight()));
-
+                if (superScriptCell != null){
+                   float superTextWidth = PdfUtil.getStringWidth(superScriptCell.getText(), superScriptCell.getFont(), superScriptCell.getFontSize());
+                    xOffset =  startX + (cell.getWidth()- (textWidth + cell.getPaddingRight())-  (superTextWidth+superScriptCell.getPaddingRight()));
+                }else{
+                    xOffset = startX + (cell.getWidth() - (textWidth + cell.getPaddingRight()));
+                }
             } else if (cell.isHorizontallyAligned(CENTER)) {
                 xOffset = startX + (cell.getWidth() - textWidth) / 2;
 
@@ -92,17 +96,8 @@ public class TextCellDrawer<T extends AbstractTextCell> extends AbstractCellDraw
                 currentFont = cell.getFont();
                 currentFontSize = cell.getFontSize();
                 currentTextColor = cell.getTextColor();
-                xOffset = startX + cell.getPaddingLeft() + textWidth;
-
+                xOffset = xOffset + textWidth;
                 final String line = cell.getText();
-                textWidth = PdfUtil.getStringWidth(line, currentFont, currentFontSize);
-
-                if (cell.isHorizontallyAligned(RIGHT)) {
-                    xOffset = startX + (cell.getWidth() - (textWidth + cell.getPaddingRight()));
-                } else if (cell.isHorizontallyAligned(CENTER)) {
-                    xOffset = startX + (cell.getWidth() - textWidth) / 2;
-                }
-
                 drawText(
                         drawingContext,
                         PositionedStyledText.builder()

--- a/src/main/java/org/vandeseer/easytable/drawing/cell/TextCellDrawer.java
+++ b/src/main/java/org/vandeseer/easytable/drawing/cell/TextCellDrawer.java
@@ -37,8 +37,6 @@ public class TextCellDrawer<T extends AbstractTextCell> extends AbstractCellDraw
         float xOffset = startX + cell.getPaddingLeft();
 
         float textWidth = 0f;
-        int superScriptFontSze;
-
 
         TextCell superScriptCell = null;
         if (cell instanceof TextCell) {

--- a/src/main/java/org/vandeseer/easytable/structure/Table.java
+++ b/src/main/java/org/vandeseer/easytable/structure/Table.java
@@ -7,6 +7,7 @@ import org.vandeseer.easytable.settings.HorizontalAlignment;
 import org.vandeseer.easytable.settings.Settings;
 import org.vandeseer.easytable.settings.VerticalAlignment;
 import org.vandeseer.easytable.structure.cell.AbstractCell;
+import org.vandeseer.easytable.structure.cell.TextCell;
 
 import java.awt.*;
 import java.util.List;
@@ -217,7 +218,7 @@ public class Table {
 
             // Set up the connections between table, row(s) and cell(s)
             for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
-                Row row = rows.get(rowIndex);
+               Row row = rows.get(rowIndex);
                 row.setTable(table);
 
                 // Fill up the settings of the row that are not set there directly
@@ -240,6 +241,15 @@ public class Table {
                     cell.setColumn(column);
 
                     cell.setWidth(getAvailableCellWidthRespectingSpan(columnIndex, cell.getColSpan()));
+
+
+                    if(cell instanceof TextCell){
+                        TextCell textCell = (TextCell) cell;
+                        if(textCell.hasSuperScript()){
+                            textCell= textCell.getSuperScript();
+                            textCell.getSettings().fillingMergeBy(row.getSettings());
+                        }
+                    }
 
                     columnIndex += cell.getColSpan();
                 }

--- a/src/main/java/org/vandeseer/easytable/structure/Table.java
+++ b/src/main/java/org/vandeseer/easytable/structure/Table.java
@@ -218,7 +218,7 @@ public class Table {
 
             // Set up the connections between table, row(s) and cell(s)
             for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
-               Row row = rows.get(rowIndex);
+                Row row = rows.get(rowIndex);
                 row.setTable(table);
 
                 // Fill up the settings of the row that are not set there directly

--- a/src/main/java/org/vandeseer/easytable/structure/cell/AbstractTextCell.java
+++ b/src/main/java/org/vandeseer/easytable/structure/cell/AbstractTextCell.java
@@ -20,6 +20,9 @@ public abstract class AbstractTextCell extends AbstractCell {
     @Builder.Default
     protected float lineSpacing = 1f;
 
+    @Builder.Default
+    protected float textRise = 0f;
+
     public PDFont getFont() {
         return settings.getFont();
     }

--- a/src/main/java/org/vandeseer/easytable/structure/cell/TextCell.java
+++ b/src/main/java/org/vandeseer/easytable/structure/cell/TextCell.java
@@ -13,8 +13,28 @@ public class TextCell extends AbstractTextCell {
     @NonNull
     protected String text;
 
+    private TextCell superScript;
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+
+    public String getText() {
+        return text;
+    }
+
+
     protected Drawer createDefaultDrawer() {
         return new TextCellDrawer(this);
+    }
+
+    public TextCell getSuperScript() {
+        return superScript;
+    }
+
+    public boolean hasSuperScript() {
+            return superScript != null;
     }
 
 }

--- a/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
+++ b/src/main/java/org/vandeseer/easytable/util/PdfUtil.java
@@ -223,7 +223,6 @@ public final class PdfUtil {
             String text = words.peek();
             float nextWordWidth;
             if(counter == size){
-                System.out.println("LAST : " + text);
                 nextWordWidth = getStringWidth(text, font, fontSize) + getStringWidth(superScript, superScriptFont, superScriptFontSize) ;
             }else{
                 nextWordWidth = getStringWidth(text, font, fontSize);

--- a/src/test/java/org/vandeseer/MinimumWorkingExample.java
+++ b/src/test/java/org/vandeseer/MinimumWorkingExample.java
@@ -36,6 +36,16 @@ public class MinimumWorkingExample {
                                 .add(TextCell.builder().text("Two One").textColor(Color.RED).build())
                                 .add(TextCell.builder().text("Two Two").horizontalAlignment(HorizontalAlignment.RIGHT).build())
                                 .build())
+                        .addRow(Row.builder()
+                                .padding(10)
+                                .add(TextCell.builder().text("The last word is to the same line").textColor(Color.RED)
+                                        .superScript(TextCell.builder().text("1").fontSize(6).textRise(5).build())
+                                        .build())
+                                .add(TextCell.builder()
+                                        .text("The last word ======> to next line").borderWidth(4).backgroundColor(Color.WHITE)
+                                        .superScript(TextCell.builder().text("2").fontSize(6).textRise(5).build())
+                                        .build())
+                                .build())
                         .build();
 
                 // Set up the drawer


### PR DESCRIPTION
I added functionality for SuperScritp.

Usage:

```
 
  .text("Hello World").borderWidth(4).backgroundColor(Color.WHITE)
  .superScript(TextCell.builder().text("2").fontSize(6).textRise(5).build())
 
```

By default textRise is 0.


Note, right now only TextCell supports this functionality. In the future , I think we need abstract methods in the AbstractTextCell to avoid casting and checking instances:

```
    public abstract boolean hasSuperScript();
    public abstract AbstractTextCell superText();
```

Under the hood we have the following:

` contentStream.setTextRise(styledText.getTextRise());`



Additionally, I add logic to move text to the next line if super-text does not fit to the current column.



